### PR TITLE
Update bitexpert/phing-securitychecker dep due to Travis problem with SSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.6
     - php: 7.0
     - php: 7.1
       env:

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <project name="prophiler-psr7-middleware" basedir="." default="security:check">
+    <property name="securitychecker.endpoint" value="http://security.sensiolabs.org/check_lock" />
     <import file="vendor/bitexpert/phing-securitychecker/build.xml" />
 
     <target name="sniff">

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     }
   ],
   "require": {
-    "php": "^5.6|^7.0",
+    "php": "^7.0",
     "psr/http-message": "^1.0",
     "fabfuel/prophiler": "^1.5 || dev-feature/php7 as 2.0",
     "zendframework/zend-stratigility": "^2.0",
@@ -27,7 +27,7 @@
     "squizlabs/php_codesniffer": "^2.3",
     "phpdocumentor/phpdocumentor": "^2.8",
     "phing/phing": "^2.8.0",
-    "bitexpert/phing-securitychecker": "^0.2.1",
+    "bitexpert/phing-securitychecker": "^0.3.1",
     "monolog/monolog": "^1.14.0"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8d8e4e2ba5a55409787b146c7b6c654a",
+    "content-hash": "4a577a9140e73034f80cc789f33c35a9",
     "packages": [
         {
             "name": "bitexpert/slf4psrlog",
@@ -357,27 +357,26 @@
     "packages-dev": [
         {
             "name": "bitexpert/phing-securitychecker",
-            "version": "0.2.1",
+            "version": "v0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bitExpert/phing-securitychecker.git",
-                "reference": "f135525228c0ce9b54e03f5fb5f7e5e408942ff1"
+                "reference": "1c059c24af59ad12e50a56c5894ecf5d06eb01df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bitExpert/phing-securitychecker/zipball/f135525228c0ce9b54e03f5fb5f7e5e408942ff1",
-                "reference": "f135525228c0ce9b54e03f5fb5f7e5e408942ff1",
+                "url": "https://api.github.com/repos/bitExpert/phing-securitychecker/zipball/1c059c24af59ad12e50a56c5894ecf5d06eb01df",
+                "reference": "1c059c24af59ad12e50a56c5894ecf5d06eb01df",
                 "shasum": ""
             },
             "require": {
                 "phing/phing": "^2.8.0",
-                "php": "^5.5|^7.0",
-                "sensiolabs/security-checker": "v3.0.2"
+                "php": "^7.0",
+                "sensiolabs/security-checker": "^4.0"
             },
             "require-dev": {
                 "phpdocumentor/phpdocumentor": "^2.8",
-                "phpunit/php-code-coverage": "^2.1.0",
-                "phpunit/phpunit": "^4.8",
+                "phpunit/phpunit": "^6.0",
                 "squizlabs/php_codesniffer": "^2.3"
             },
             "type": "library",
@@ -402,7 +401,7 @@
                 "Security Checker",
                 "phing"
             ],
-            "time": "2015-11-07T19:14:18+00:00"
+            "time": "2017-05-26T08:53:20+00:00"
         },
         {
             "name": "cilex/cilex",
@@ -521,6 +520,65 @@
                 "silex"
             ],
             "time": "2012-12-19T10:50:58+00:00"
+        },
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "reference": "b17e6153cb7f33c7e44eb59578dc12eee5dc8e12",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5",
+                "psr/log": "^1.0",
+                "symfony/process": "^2.5 || ^3.0"
+            },
+            "suggest": {
+                "symfony/process": "This is necessary to reliably check whether openssl_x509_parse is vulnerable on older php versions, but can be ignored on PHP 5.5.6+"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "time": "2017-03-06T11:59:08+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -2711,20 +2769,21 @@
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v3.0.2",
+            "version": "v4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "21696b0daa731064c23cfb694c60a2584a7b6e93"
+                "reference": "9e69eddf3bc49d1ee5c7908564da3141796d4bbc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/21696b0daa731064c23cfb694c60a2584a7b6e93",
-                "reference": "21696b0daa731064c23cfb694c60a2584a7b6e93",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/9e69eddf3bc49d1ee5c7908564da3141796d4bbc",
+                "reference": "9e69eddf3bc49d1ee5c7908564da3141796d4bbc",
                 "shasum": ""
             },
             "require": {
-                "symfony/console": "~2.0|~3.0"
+                "composer/ca-bundle": "^1.0",
+                "symfony/console": "~2.7|~3.0"
             },
             "bin": [
                 "security-checker"
@@ -2732,7 +2791,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2751,7 +2810,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2015-11-07T08:07:40+00:00"
+            "time": "2017-03-31T14:50:32+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4279,7 +4338,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6|^7.0"
+        "php": "^7.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
This should fix the build problem on Travis regarding the SSL certificate of the securitychecker webservice.

In addition to that we use PHP 7 as minimum version requirement as bitexpert/phing-securitychecker requires PHP 7 by now. 