### PR TITLE
update fabfuel/prophiler to version 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require": {
     "php": "^7.0",
     "psr/http-message": "^1.0",
-    "fabfuel/prophiler": "^1.5 || dev-feature/php7 as 2.0",
+    "fabfuel/prophiler": "^1.6",
     "zendframework/zend-stratigility": "^2.0",
     "bitexpert/slf4psrlog": "^0.1.0"
   },


### PR DESCRIPTION
fabfuel has just released version 1.6, which drops support for php_v5.4 and adds support for php_v7.0 and v7.1 (https://github.com/fabfuel/prophiler/releases/tag/1.6.0).